### PR TITLE
Hardcodes Osmosis denom in save_asset reply

### DIFF
--- a/src/implementations/cw20.rs
+++ b/src/implementations/cw20.rs
@@ -166,8 +166,8 @@ pub struct Cw20Instantiator {
 }
 
 impl Instantiate<Cw20> for Cw20Instantiator {
-    fn instantiate_msg(&self) -> StdResult<SubMsg> {
-        Ok(SubMsg::reply_always(
+    fn instantiate_res(&self, _env: &Env) -> StdResult<Response> {
+        let init_msg = SubMsg::reply_always(
             WasmMsg::Instantiate {
                 admin: self.admin.clone(),
                 code_id: self.code_id,
@@ -176,7 +176,8 @@ impl Instantiate<Cw20> for Cw20Instantiator {
                 label: self.label.clone(),
             },
             REPLY_SAVE_CW20_ADDRESS,
-        ))
+        );
+        Ok(Response::new().add_submessage(init_msg))
     }
 
     fn save_asset(

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    Addr, Binary, DepsMut, Env, QuerierWrapper, Reply, Response, StdResult, SubMsg, Uint128,
+    Addr, Binary, DepsMut, Env, QuerierWrapper, Reply, Response, StdResult, Uint128,
 };
 use cw_storage_plus::Item;
 use serde::{de::DeserializeOwned, Serialize};
@@ -7,7 +7,7 @@ use std::fmt::Display;
 
 use crate::CwTokenError;
 pub trait Instantiate<A: Serialize + DeserializeOwned>: Sized {
-    fn instantiate_msg(&self) -> StdResult<SubMsg>;
+    fn instantiate_res(&self, env: &Env) -> StdResult<Response>;
 
     fn save_asset(
         deps: DepsMut,


### PR DESCRIPTION
Events from non-wasm modules are no longer returned, so we will pass the Event ourselves with the denom instead to what is expected from TokenFactory - `factory/{INSTANTIATOR_ADDRESS}/{DENOM_NAME}`