### PR TITLE
Instantiate

### DIFF
--- a/src/implementations/cw20.rs
+++ b/src/implementations/cw20.rs
@@ -111,7 +111,7 @@ impl Cw20 {
 }
 
 impl Instantiate for Cw20 {
-    fn instantiate(&self, _deps: DepsMut, init_info: Option<Binary>) -> CwTokenResponse {
+    fn instantiate(_deps: DepsMut, _env: &Env, init_info: Option<Binary>) -> CwTokenResponse {
         let msg: Cw20InitInfo =
             from_binary(&init_info.ok_or(StdError::generic_err("init_info requried for Cw20"))?)?;
 

--- a/src/implementations/cw4626.rs
+++ b/src/implementations/cw4626.rs
@@ -185,7 +185,7 @@ impl Burn for Cw4626 {
 }
 
 impl Instantiate for Cw4626 {
-    fn instantiate(&self, deps: DepsMut, init_info: Option<Binary>) -> CwTokenResponse {
+    fn instantiate(deps: DepsMut, _env: &Env, init_info: Option<Binary>) -> CwTokenResponse {
         let msg: InstantiateMsg =
             from_binary(&init_info.ok_or(StdError::generic_err("init_info requried for Cw4626"))?)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 mod error;
 mod implementations;
+mod state;
 mod token;
 
 pub use error::*;
 pub use implementations::*;
+pub use state::*;
 pub use token::*;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,21 @@
+use crate::CwTokenError;
+use cosmwasm_std::Storage;
+use cw_storage_plus::Item;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+pub(crate) const STORE_TOKEN_KEY: &str = "store_token";
+
+pub trait TokenStorage: Serialize + DeserializeOwned + Sized {
+    fn load(storage: &dyn Storage) -> Result<Self, CwTokenError> {
+        Ok(Self::get_item().load(storage)?)
+    }
+
+    fn save(&self, storage: &mut dyn Storage) -> Result<(), CwTokenError> {
+        Ok(Self::get_item().save(storage, self)?)
+    }
+
+    fn get_item<'a>() -> Item<'a, Self> {
+        Item::<Self>::new(STORE_TOKEN_KEY)
+    }
+}

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Uint128};
+use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Reply, Uint128};
 
 use std::fmt::Display;
 
@@ -34,6 +34,30 @@ pub trait Instantiate {
     /// }
     /// ```
     fn instantiate(deps: DepsMut, env: &Env, init_info: Option<Binary>) -> CwTokenResponse;
+
+    /// Saves the token to the storage in the provided `item`. This function should
+    /// be called in the `reply` entry point of the contract after `Self::instantiate`
+    /// has been called in the `instantiate` entry point.
+    ///
+    /// Arguments:
+    /// - reply: The reply received to the `reply` entry point.
+    /// - item: The `Item` to which the token should be saved.
+    ///
+    /// Returns a Response containing the messages to save the instantiated token.
+    ///
+    /// This is needed because as opposed to OsmosisDenom and Cw4626, when
+    /// instantiating a Cw20 we don't know the address until after we receive a reply.
+    ///
+    /// ## Example
+    /// ```
+    /// #[cfg_attr(not(feature = "library"), entry_point)]
+    /// pub fn reply(deps: DepsMut, env: Env, reply: Reply) -> Result<Response, ContractError> {
+    ///     MyToken::reply_save_token(deps, env, reply)
+    /// }
+    /// ```
+    fn reply_save_token(_deps: DepsMut, _env: &Env, _reply: &Reply) -> CwTokenResponse {
+        unimplemented!()
+    }
 }
 
 pub trait Token: Display {

--- a/src/token.rs
+++ b/src/token.rs
@@ -33,7 +33,7 @@ pub trait Instantiate {
     ///     my_token.instantiate(deps, to_binary(&msg.init_info)?)
     /// }
     /// ```
-    fn instantiate(&self, deps: DepsMut, init_info: Option<Binary>) -> CwTokenResponse;
+    fn instantiate(deps: DepsMut, env: &Env, init_info: Option<Binary>) -> CwTokenResponse;
 }
 
 pub trait Token: Display {


### PR DESCRIPTION
this PR changes the Instantiate token trait in the following ways
- removes self reference in arguments (Token is expected to be created for the first time when using this trait, so the Token object should be created and stored within Instantiate)
- adds TokenStorage trait for storing/getting the token address to/from contract state (copied over from steak-contracts)
- adds Env to instantiate arguments for setting the sender address in OsmosisDenom
- adds reply_save_token() to Instantiate trait, with default implementation as unimplemented() to not force implementation. This is used by Cw20s since they won't know the address until after the Cw20 is created